### PR TITLE
2025.11.1

### DIFF
--- a/themes/transparentblue.yaml
+++ b/themes/transparentblue.yaml
@@ -35,7 +35,7 @@ transparentblue:
   accent-color: 'var(--primary-color)'
   border-color: 'transparent'
   input-dropdown-icon-color: 'var(--primary-color)'  # Fix the dropdown and X selector when in UI for adding entities to a card, etc.
-  mdc-radio-unchecked-color: 'rgb(255,255,255,0.5'  # Radio unselected color
+  mdc-radio-unchecked-color: 'rgb(255,255,255,0.5)'  # Radio unselected color
   ha-color-fill-neutral-quiet-resting: 'var(--main-color)'
   ha-color-fill-primary-normal-resting: 'var(--main-color)'
   ha-color-fill-primary-quiet-resting: 'var(--main-color-2)'

--- a/themes/transparentblue.yaml
+++ b/themes/transparentblue.yaml
@@ -36,6 +36,8 @@ transparentblue:
   border-color: 'transparent'
   input-dropdown-icon-color: 'var(--primary-color)'  # Fix the dropdown and X selector when in UI for adding entities to a card, etc.
   mdc-radio-unchecked-color: 'rgb(255,255,255,0.5'  # Radio unselected color
+  ha-color-fill-neutral-quiet-resting: 'var(--main-color)'
+  ha-color-fill-primary-normal-resting: 'var(--main-color)'
   #error-color: "var(--primary-color)" #Error color | Stock: #db4437, #b00020
   clear-background-color: "var(--accent-color)"  # Used at leasr for the little drag value indicator, e.g. for fan controls.
   #Text

--- a/themes/transparentblue.yaml
+++ b/themes/transparentblue.yaml
@@ -38,7 +38,7 @@ transparentblue:
   mdc-radio-unchecked-color: 'rgb(255,255,255,0.5'  # Radio unselected color
   ha-color-fill-neutral-quiet-resting: 'var(--main-color)'
   ha-color-fill-primary-normal-resting: 'var(--main-color)'
-  ha-color-fill-primary-quiet-resting: 'var(--main-color-2'
+  ha-color-fill-primary-quiet-resting: 'var(--main-color-2)'
   ha-color-on-neutral-quiet: 'var(--text-color)'
   ha-color-text-secondary: 'var(--text-color)'
   #error-color: "var(--primary-color)" #Error color | Stock: #db4437, #b00020

--- a/themes/transparentblue.yaml
+++ b/themes/transparentblue.yaml
@@ -38,6 +38,9 @@ transparentblue:
   mdc-radio-unchecked-color: 'rgb(255,255,255,0.5'  # Radio unselected color
   ha-color-fill-neutral-quiet-resting: 'var(--main-color)'
   ha-color-fill-primary-normal-resting: 'var(--main-color)'
+  ha-color-fill-primary-quiet-resting: 'var(--main-color-2'
+  ha-color-on-neutral-quiet: 'var(--text-color)'
+  ha-color-text-secondary: 'var(--text-color)'
   #error-color: "var(--primary-color)" #Error color | Stock: #db4437, #b00020
   clear-background-color: "var(--accent-color)"  # Used at leasr for the little drag value indicator, e.g. for fan controls.
   #Text

--- a/themes/transparentblue.yaml
+++ b/themes/transparentblue.yaml
@@ -42,7 +42,7 @@ transparentblue:
   ha-color-on-neutral-quiet: 'var(--text-color)'
   ha-color-text-secondary: 'var(--text-color)'
   #error-color: "var(--primary-color)" #Error color | Stock: #db4437, #b00020
-  clear-background-color: "var(--accent-color)"  # Used at leasr for the little drag value indicator, e.g. for fan controls.
+  clear-background-color: "var(--accent-color)"  # Used at least for the little drag value indicator, e.g. for fan controls.
   #Text
   primary-color: ''  # Do not set, this ensures colors are readable in places like logbook, dev tools, hyperlinks, selected header text, + Add integration, on state switches, selected checkbox background, pretty much anywhere you see the signature Home Assistant blue. Might be able to find A color that would work.
   text-primary-color: ''  # Primary text color


### PR DESCRIPTION
This pull request updates the `transparentblue` theme by adding several new color variables to improve consistency and support for UI elements. The changes mainly introduce new color assignments using existing theme variables.

Theme improvements:

* Added `ha-color-fill-neutral-quiet-resting`, `ha-color-fill-primary-normal-resting`, and `ha-color-fill-primary-quiet-resting` variables, all mapped to existing main color variables for consistent UI coloring.
* Added `ha-color-on-neutral-quiet` and `ha-color-text-secondary` variables, both set to use the main text color, improving text color consistency across the theme.## Pull Request Template

